### PR TITLE
Bump the plugin's version to publish it to Spine Cloud repo

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.7`
+# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.8`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -751,4 +751,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Oct 10 18:46:23 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 12 17:04:44 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords-Gradle-plugin</artifactId>
-<version>1.9.7</version>
+<version>1.9.8</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -33,4 +33,4 @@
  *
  * The version should be updated to `2.0.x` after migrating to Spine `2.0.x`.
  */
-val gradlePluginVersion: String by extra("1.9.7")
+val gradlePluginVersion: String by extra("1.9.8")


### PR DESCRIPTION
This PR just bumps the plugin's version to publish it to the Spine Cloud repo. 

This is necessary because the previous build was done with the same version as in the Shords repository.