### PR TITLE
Update `ApplyCodegenPlugins` Gradle task execution timeout

### DIFF
--- a/buildSrc/src/main/kotlin/detekt-code-analysis.gradle.kts
+++ b/buildSrc/src/main/kotlin/detekt-code-analysis.gradle.kts
@@ -73,7 +73,7 @@ detekt {
     //   module's content. The custom config adds Compose-specific declarations.
     //   See whether/how `config` can be updated accordingly.
     //   See https://github.com/SpineEventEngine/Chords/issues/3
-    config.from(files("${rootDir}/config/quality/detekt-config.yml"))
+    config.from(files("${rootDir}/config/buildSrc/quality/detekt-config.yml"))
 }
 
 tasks {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.20`
+# Dependencies of `io.spine.chords:spine-chords-gradle-plugin:1.9.21`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -751,4 +751,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 21 20:27:54 EEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 29 10:48:38 EET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/src/functionalTest/kotlin/io/spine/chords/gradle/Given.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/io/spine/chords/gradle/Given.kt
@@ -52,7 +52,7 @@ repositories {
 chordsGradlePlugin {
     protoDependencies("io.spine:spine-money:1.5.0")
     codegenPluginsArtifact = 
-        "io.spine.chords:spine-chords-codegen-plugins:2.0.0-SNAPSHOT.35"
+        "io.spine.chords:spine-chords-codegen-plugins:2.0.0-SNAPSHOT.81"
 }
 
 """.trimIndent()

--- a/gradle-plugin/src/main/kotlin/io/spine/chords/gradle/ApplyCodegenPlugins.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/chords/gradle/ApplyCodegenPlugins.kt
@@ -30,7 +30,7 @@ public open class ApplyCodegenPlugins : DefaultTask() {
         /**
          * Default Gradle build timeout.
          */
-        private const val BUILD_TIMEOUT_MINUTES: Long = 10
+        private const val BUILD_TIMEOUT_MINUTES: Long = 20
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.chords</groupId>
 <artifactId>Chords-Gradle-plugin</artifactId>
-<version>1.9.20</version>
+<version>1.9.21</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -33,4 +33,4 @@
  *
  * The version should be updated to `2.0.x` after migrating to Spine `2.0.x`.
  */
-val gradlePluginVersion: String by extra("1.9.20")
+val gradlePluginVersion: String by extra("1.9.21")


### PR DESCRIPTION
This PR updates the execution timeout for the `ApplyCodegenPlugins` Gradle tasks.

This change is necessary because the 1DAM project CI build times out when executing the `ApplyCodegenPlugins` task on Windows.